### PR TITLE
att

### DIFF
--- a/serial_led_control/inc/ssd1306.c
+++ b/serial_led_control/inc/ssd1306.c
@@ -1,196 +1,61 @@
 #include "ssd1306.h"
-#include "font.h"
+#include <stdlib.h>
 
-void ssd1306_init(ssd1306_t *ssd, uint8_t width, uint8_t height, bool external_vcc, uint8_t address, i2c_inst_t *i2c) {
-  ssd->width = width;
-  ssd->height = height;
-  ssd->pages = height / 8U;
-  ssd->address = address;
-  ssd->i2c_port = i2c;
-  ssd->bufsize = ssd->pages * ssd->width + 1;
-  ssd->ram_buffer = calloc(ssd->bufsize, sizeof(uint8_t));
-  ssd->ram_buffer[0] = 0x40;
-  ssd->port_buffer[0] = 0x80;
-}
+// Inicializa o display
+void ssd1306_init(ssd1306_t *ssd, i2c_inst_t *i2c_port) {
+    ssd->width = SSD1306_WIDTH;
+    ssd->height = SSD1306_HEIGHT;
+    ssd->pages = SSD1306_HEIGHT / 8;
+    ssd->external_vcc = false;
+    ssd->i2c_port = i2c_port;
+    
+    // Aloca o buffer (128x64 pixels / 8 bits por byte)
+    ssd->buffer = (uint8_t*)malloc(SSD1306_WIDTH * ssd->pages);
+    memset(ssd->buffer, 0, SSD1306_WIDTH * ssd->pages);
 
-void ssd1306_config(ssd1306_t *ssd) {
-  ssd1306_command(ssd, SET_DISP | 0x00);
-  ssd1306_command(ssd, SET_MEM_ADDR);
-  ssd1306_command(ssd, 0x01);
-  ssd1306_command(ssd, SET_DISP_START_LINE | 0x00);
-  ssd1306_command(ssd, SET_SEG_REMAP | 0x01);
-  ssd1306_command(ssd, SET_MUX_RATIO);
-  ssd1306_command(ssd, HEIGHT - 1);
-  ssd1306_command(ssd, SET_COM_OUT_DIR | 0x08);
-  ssd1306_command(ssd, SET_DISP_OFFSET);
-  ssd1306_command(ssd, 0x00);
-  ssd1306_command(ssd, SET_COM_PIN_CFG);
-  ssd1306_command(ssd, 0x12);
-  ssd1306_command(ssd, SET_DISP_CLK_DIV);
-  ssd1306_command(ssd, 0x80);
-  ssd1306_command(ssd, SET_PRECHARGE);
-  ssd1306_command(ssd, 0xF1);
-  ssd1306_command(ssd, SET_VCOM_DESEL);
-  ssd1306_command(ssd, 0x30);
-  ssd1306_command(ssd, SET_CONTRAST);
-  ssd1306_command(ssd, 0xFF);
-  ssd1306_command(ssd, SET_ENTIRE_ON);
-  ssd1306_command(ssd, SET_NORM_INV);
-  ssd1306_command(ssd, SET_CHARGE_PUMP);
-  ssd1306_command(ssd, 0x14);
-  ssd1306_command(ssd, SET_DISP | 0x01);
-}
+    // Sequência de inicialização
+    uint8_t init_sequence[] = {
+        SSD1306_SET_DISPLAY_OFF,
+        SSD1306_SET_MEMORY_MODE, 0x00, // Modo horizontal
+        SSD1306_SET_DISPLAY_START,
+        SSD1306_SET_SEG_REMAP | 0x01,  // Flip horizontal
+        SSD1306_SET_MUX_RATIO, 0x3F,
+        SSD1306_SET_COM_SCAN_DIR | 0x08, // Flip vertical
+        SSD1306_SET_DISPLAY_OFFSET, 0x00,
+        SSD1306_SET_COM_PINS, 0x12,
+        SSD1306_SET_CONTRAST, 0x7F,
+        SSD1306_SET_PRECHARGE, 0xF1,
+        SSD1306_SET_VCOM_DESELECT, 0x40,
+        SSD1306_SET_CHARGE_PUMP, 0x14, // Habilita charge pump
+        SSD1306_SET_DISPLAY_ON
+    };
 
-void ssd1306_command(ssd1306_t *ssd, uint8_t command) {
-  ssd->port_buffer[1] = command;
-  i2c_write_blocking(
-    ssd->i2c_port,
-    ssd->address,
-    ssd->port_buffer,
-    2,
-    false
-  );
-}
-
-void ssd1306_send_data(ssd1306_t *ssd) {
-  ssd1306_command(ssd, SET_COL_ADDR);
-  ssd1306_command(ssd, 0);
-  ssd1306_command(ssd, ssd->width - 1);
-  ssd1306_command(ssd, SET_PAGE_ADDR);
-  ssd1306_command(ssd, 0);
-  ssd1306_command(ssd, ssd->pages - 1);
-  i2c_write_blocking(
-    ssd->i2c_port,
-    ssd->address,
-    ssd->ram_buffer,
-    ssd->bufsize,
-    false
-  );
-}
-
-void ssd1306_pixel(ssd1306_t *ssd, uint8_t x, uint8_t y, bool value) {
-  uint16_t index = (y >> 3) + (x << 3) + 1;
-  uint8_t pixel = (y & 0b111);
-  if (value)
-    ssd->ram_buffer[index] |= (1 << pixel);
-  else
-    ssd->ram_buffer[index] &= ~(1 << pixel);
-}
-
-/*
-void ssd1306_fill(ssd1306_t *ssd, bool value) {
-  uint8_t byte = value ? 0xFF : 0x00;
-  for (uint8_t i = 1; i < ssd->bufsize; ++i)
-    ssd->ram_buffer[i] = byte;
-}*/
-
-void ssd1306_fill(ssd1306_t *ssd, bool value) {
-    // Itera por todas as posições do display
-    for (uint8_t y = 0; y < ssd->height; ++y) {
-        for (uint8_t x = 0; x < ssd->width; ++x) {
-            ssd1306_pixel(ssd, x, y, value);
-        }
+    // Envia os comandos via I2C
+    for (size_t i = 0; i < sizeof(init_sequence); i++) {
+        uint8_t cmd[] = {0x00, init_sequence[i]}; // 0x00 = Co bit (command)
+        i2c_write_blocking(ssd->i2c_port, SSD1306_ADDRESS, cmd, 2, false);
     }
 }
 
-
-
-void ssd1306_rect(ssd1306_t *ssd, uint8_t top, uint8_t left, uint8_t width, uint8_t height, bool value, bool fill) {
-  for (uint8_t x = left; x < left + width; ++x) {
-    ssd1306_pixel(ssd, x, top, value);
-    ssd1306_pixel(ssd, x, top + height - 1, value);
-  }
-  for (uint8_t y = top; y < top + height; ++y) {
-    ssd1306_pixel(ssd, left, y, value);
-    ssd1306_pixel(ssd, left + width - 1, y, value);
-  }
-
-  if (fill) {
-    for (uint8_t x = left + 1; x < left + width - 1; ++x) {
-      for (uint8_t y = top + 1; y < top + height - 1; ++y) {
-        ssd1306_pixel(ssd, x, y, value);
-      }
-    }
-  }
+// Limpa o buffer
+void ssd1306_clear(ssd1306_t *ssd) {
+    memset(ssd->buffer, 0, SSD1306_WIDTH * ssd->pages);
 }
 
-void ssd1306_line(ssd1306_t *ssd, uint8_t x0, uint8_t y0, uint8_t x1, uint8_t y1, bool value) {
-    int dx = abs(x1 - x0);
-    int dy = abs(y1 - y0);
-
-    int sx = (x0 < x1) ? 1 : -1;
-    int sy = (y0 < y1) ? 1 : -1;
-
-    int err = dx - dy;
-
-    while (true) {
-        ssd1306_pixel(ssd, x0, y0, value); // Desenha o pixel atual
-
-        if (x0 == x1 && y0 == y1) break; // Termina quando alcança o ponto final
-
-        int e2 = err * 2;
-
-        if (e2 > -dy) {
-            err -= dy;
-            x0 += sx;
-        }
-
-        if (e2 < dx) {
-            err += dx;
-            y0 += sy;
-        }
+// Atualiza o display
+void ssd1306_update(ssd1306_t *ssd) {
+    for (uint8_t page = 0; page < ssd->pages; page++) {
+        uint8_t cmd[] = {
+            0x00, // Co bit (command)
+            SSD1306_SET_PAGE_ADDR, page, page, // Define a página
+            SSD1306_SET_COL_ADDR, 0, SSD1306_WIDTH - 1 // Define a coluna
+        };
+        i2c_write_blocking(ssd->i2c_port, SSD1306_ADDRESS, cmd, sizeof(cmd), false);
+        
+        // Envia os dados da página
+        uint8_t data[SSD1306_WIDTH + 1];
+        data[0] = 0x40; // Co bit (data)
+        memcpy(data + 1, &ssd->buffer[page * SSD1306_WIDTH], SSD1306_WIDTH);
+        i2c_write_blocking(ssd->i2c_port, SSD1306_ADDRESS, data, sizeof(data), false);
     }
-}
-
-
-void ssd1306_hline(ssd1306_t *ssd, uint8_t x0, uint8_t x1, uint8_t y, bool value) {
-  for (uint8_t x = x0; x <= x1; ++x)
-    ssd1306_pixel(ssd, x, y, value);
-}
-
-void ssd1306_vline(ssd1306_t *ssd, uint8_t x, uint8_t y0, uint8_t y1, bool value) {
-  for (uint8_t y = y0; y <= y1; ++y)
-    ssd1306_pixel(ssd, x, y, value);
-}
-
-// Função para desenhar um caractere
-void ssd1306_draw_char(ssd1306_t *ssd, char c, uint8_t x, uint8_t y)
-{
-  uint16_t index = 0;
-  char ver=c;
-  if (c >= 'A' && c <= 'Z')
-  {
-    index = (c - 'A' + 11) * 8; // Para letras maiúsculas
-  }else  if (c >= '0' && c <= '9')
-  {
-    index = (c - '0' + 1) * 8; // Adiciona o deslocamento necessário
-  }
-  
-  for (uint8_t i = 0; i < 8; ++i)
-  {
-    uint8_t line = font[index + i];
-    for (uint8_t j = 0; j < 8; ++j)
-    {
-      ssd1306_pixel(ssd, x + i, y + j, line & (1 << j));
-    }
-  }
-}
-
-// Função para desenhar uma string
-void ssd1306_draw_string(ssd1306_t *ssd, const char *str, uint8_t x, uint8_t y)
-{
-  while (*str)
-  {
-    ssd1306_draw_char(ssd, *str++, x, y);
-    x += 8;
-    if (x + 8 >= ssd->width)
-    {
-      x = 0;
-      y += 8;
-    }
-    if (y + 8 >= ssd->height)
-    {
-      break;
-    }
-  }
 }

--- a/serial_led_control/inc/ssd1306.h
+++ b/serial_led_control/inc/ssd1306.h
@@ -1,53 +1,50 @@
 #ifndef SSD1306_H
 #define SSD1306_H
 
-#include <stdlib.h>
+#include <stdbool.h>
 #include "pico/stdlib.h"
 #include "hardware/i2c.h"
 
-#define WIDTH 128
-#define HEIGHT 64
-#define SSD1306_I2C_ADDR 0x3C
+// Definições do display
+#define SSD1306_WIDTH  128
+#define SSD1306_HEIGHT 64
+#define SSD1306_ADDRESS 0x3C
 
-// Comandos do SSD1306 (como já fornecido no seu código)
-typedef enum {
-  SET_CONTRAST = 0x81,
-  SET_ENTIRE_ON = 0xA4,
-  SET_NORM_INV = 0xA6,
-  SET_DISP = 0xAE,
-  SET_MEM_ADDR = 0x20,
-  SET_COL_ADDR = 0x21,
-  SET_PAGE_ADDR = 0x22,
-  SET_DISP_START_LINE = 0x40,
-  SET_SEG_REMAP = 0xA0,
-  SET_MUX_RATIO = 0xA8,
-  SET_COM_OUT_DIR = 0xC0,
-  SET_DISP_OFFSET = 0xD3,
-  SET_COM_PIN_CFG = 0xDA,
-  SET_DISP_CLK_DIV = 0xD5,
-  SET_PRECHARGE = 0xD9,
-  SET_VCOM_DESEL = 0xDB,
-  SET_CHARGE_PUMP = 0x8D
-} ssd1306_command_t;
+// Comandos do SSD1306 (valores hexadecimais)
+#define SSD1306_SET_CONTRAST         0x81
+#define SSD1306_SET_ENTIRE_ON        0xA4
+#define SSD1306_SET_NORMAL_DISPLAY   0xA6
+#define SSD1306_SET_DISPLAY_OFF      0xAE
+#define SSD1306_SET_DISPLAY_ON       0xAF
+#define SSD1306_SET_MEMORY_MODE      0x20
+#define SSD1306_SET_COL_ADDR         0x21
+#define SSD1306_SET_PAGE_ADDR        0x22
+#define SSD1306_SET_DISPLAY_START    0x40
+#define SSD1306_SET_SEG_REMAP        0xA0
+#define SSD1306_SET_MUX_RATIO        0xA8
+#define SSD1306_SET_COM_SCAN_DIR     0xC0
+#define SSD1306_SET_DISPLAY_OFFSET   0xD3
+#define SSD1306_SET_COM_PINS         0xDA
+#define SSD1306_SET_DISPLAY_CLOCK    0xD5
+#define SSD1306_SET_PRECHARGE        0xD9
+#define SSD1306_SET_VCOM_DESELECT    0xDB
+#define SSD1306_SET_CHARGE_PUMP      0x8D
 
-// Definindo estrutura para o SSD1306
+// Estrutura principal do display
 typedef struct {
-  uint8_t width, height, pages, address;
-  i2c_inst_t *i2c_port;
-  bool external_vcc;
-  uint8_t *ram_buffer;
-  size_t bufsize;
-  uint8_t port_buffer[2];
+    uint8_t width;          // Largura do display (128)
+    uint8_t height;         // Altura do display (64)
+    uint8_t pages;          // Número de páginas (8 para 64 pixels de altura)
+    bool external_vcc;      // Fonte de alimentação externa (true/false)
+    i2c_inst_t *i2c_port;   // Porta I2C (ex: i2c0 ou i2c1)
+    uint8_t *buffer;        // Buffer de dados da tela
 } ssd1306_t;
 
-void ssd1306_init(ssd1306_t *ssd, uint8_t width, uint8_t height, bool external_vcc, uint8_t address, i2c_inst_t *i2c);
-void ssd1306_config(ssd1306_t *ssd);
-void ssd1306_command(ssd1306_t *ssd, uint8_t command);
-void ssd1306_send_data(ssd1306_t *ssd);
+// Protótipos de funções
+void ssd1306_init(ssd1306_t *ssd, i2c_inst_t *i2c_port); // Inicialização simplificada
+void ssd1306_clear(ssd1306_t *ssd);                      // Limpa o buffer
+void ssd1306_update(ssd1306_t *ssd);                     // Envia o buffer para o display
+void ssd1306_draw_pixel(ssd1306_t *ssd, uint8_t x, uint8_t y, bool color); // Desenha um pixel
+void ssd1306_draw_char(ssd1306_t *ssd, uint8_t x, uint8_t y, char ch);     // Desenha um caractere
 
-void ssd1306_pixel(ssd1306_t *ssd, uint8_t x, uint8_t y, bool value);
-void ssd1306_fill(ssd1306_t *ssd, bool value);
-void ssd1306_clear(ssd1306_t *ssd);   // Declaração
-void ssd1306_update(ssd1306_t *ssd);  // Declaração
-
-#endif  // SSD1306_H
+#endif // SSD1306_H

--- a/serial_led_control/inc/ws2812.h
+++ b/serial_led_control/inc/ws2812.h
@@ -9,7 +9,7 @@
 #ifdef PICO_DEFAULT_WS2812_PIN
     #define WS2812_PIN PICO_DEFAULT_WS2812_PIN
 #else
-    #define WS2812_PIN 2  // ajuste para o pino que estiver usando
+#define WS2812_PIN 7 // Use o pino GPIO 7// ajuste para o pino que estiver usando
 #endif
 
 #ifdef __cplusplus

--- a/serial_led_control/serial_led_control.c
+++ b/serial_led_control/serial_led_control.c
@@ -8,7 +8,6 @@
 #include "ws2812.h"
 
 // Definições de pinos
-#define WS2812_PIN 7
 #define LED_RGB_RED_PIN 11
 #define LED_RGB_GREEN_PIN 12
 #define LED_RGB_BLUE_PIN 13


### PR DESCRIPTION
Este repositório contém atualizações para o controle de LEDs WS2812 e display SSD1306 utilizando a placa RP2040. Algumas das principais melhorias incluem:

    Simplificação da Estrutura ssd1306_t:
        Remoção de campos redundantes como port_buffer e address.
        Adição de buffer para armazenar os pixels da tela.

    Inicialização Simplificada:
        Função ssd1306_init agora recebe apenas a porta I2C.

    Funções Essenciais Implementadas:
        ssd1306_clear() para limpar o buffer.
        ssd1306_update() para enviar o buffer para o display.
        Funções para desenho básico: ssd1306_draw_pixel() e ssd1306_draw_char().